### PR TITLE
Add missing `scope` param for `useScopedI18n` and `getScopedI18n`

### DIFF
--- a/src/i18n/client.tsx
+++ b/src/i18n/client.tsx
@@ -18,7 +18,9 @@ export const {
 });
 
 export const useUnsafeI18n = useI18n as unknown as () => UnsafeT;
-export const useUnsafeScopedI18n = useScopedI18n as unknown as () => UnsafeT;
+export const useUnsafeScopedI18n = useScopedI18n as unknown as (
+  scope: string,
+) => UnsafeT;
 
 export function I18nProvider({
   children,

--- a/src/i18n/server.ts
+++ b/src/i18n/server.ts
@@ -7,5 +7,6 @@ export const { getI18n, getScopedI18n, getStaticParams } = createI18nServer({
 });
 
 export const getUnsafeI18n = getI18n as unknown as () => Promise<UnsafeT>;
-export const getUnsafeScopedI18n =
-  getScopedI18n as unknown as () => Promise<UnsafeT>;
+export const getUnsafeScopedI18n = getScopedI18n as unknown as (
+  scope: string,
+) => Promise<UnsafeT>;


### PR DESCRIPTION
This pull request updates the type definitions for scoped i18n functions in both the client and server modules to improve type safety and ensure proper handling of scoped translations.

### Updates to scoped i18n functions:

* [`src/i18n/client.tsx`](diffhunk://#diff-29fbe4f87ffcf47291b028a7aaa1ca300e851967e93446b4a58d2a2147e3db2aL21-R23): Modified the `useUnsafeScopedI18n` function to include a `scope` parameter in its type definition.
* [`src/i18n/server.ts`](diffhunk://#diff-b27e963077c9233b59692c7d1c2183736c04d78130aab5d4dfb5cbfd67359326L10-R12): Updated the `getUnsafeScopedI18n` function to include a `scope` parameter in its type definition.