### PR TITLE
Set `<html>` tag `lang` attribute & add `[DEV]` page title prefix

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,5 +1,4 @@
 import { Toaster } from '@/components/ui/sonner';
-import { I18nProvider } from '@/i18n/client';
 import { type Locale, defaultLocale, isLocale } from '@/i18n/i18n';
 import { cn } from '@/lib/utils';
 import { Inter as FontSans } from 'next/font/google';
@@ -28,11 +27,9 @@ export default async function Layout({
           'min-h-screen bg-background font-sans antialiased',
           fontSans.variable,
         )}>
-        <Providers>
-          <I18nProvider locale={computedLocale}>
-            {children}
-            <Toaster />
-          </I18nProvider>
+        <Providers locale={computedLocale}>
+          {children}
+          <Toaster />
         </Providers>
       </body>
     </html>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,7 +1,12 @@
 import { Toaster } from '@/components/ui/sonner';
 import { I18nProvider } from '@/i18n/client';
 import { type Locale, defaultLocale, isLocale } from '@/i18n/i18n';
+import { cn } from '@/lib/utils';
+import { Inter as FontSans } from 'next/font/google';
 import type { ReactElement } from 'react';
+import Providers from '../providers';
+
+const fontSans = FontSans({ subsets: ['latin'], variable: '--font-sans' });
 
 export default async function Layout({
   params,
@@ -17,9 +22,19 @@ export default async function Layout({
   }
 
   return (
-    <I18nProvider locale={computedLocale}>
-      {children}
-      <Toaster />
-    </I18nProvider>
+    <html lang={computedLocale} suppressHydrationWarning>
+      <body
+        className={cn(
+          'min-h-screen bg-background font-sans antialiased',
+          fontSans.variable,
+        )}>
+        <Providers>
+          <I18nProvider locale={computedLocale}>
+            {children}
+            <Toaster />
+          </I18nProvider>
+        </Providers>
+      </body>
+    </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,14 +3,14 @@ import type { ReactNode } from 'react';
 import './globals.css';
 import env from '@/env';
 
-export const metadata: Metadata = {
-  title: 'NextJS Template',
-  description: 'NextJS template project',
-};
-
-const isDevelopment = env.NODE_ENV === 'development';
-if (isDevelopment) {
-  metadata.title = `[DEV] ${metadata.title}`;
+export function generateMetadata(): Metadata {
+  const baseTitle = 'NextJS Template';
+  const isDevelopment = env.NODE_ENV === 'development';
+  const title = isDevelopment ? `[DEV] ${baseTitle}` : baseTitle;
+  return {
+    title,
+    description: 'NextJS template project',
+  };
 }
 
 export default function RootLayout({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   description: 'NextJS template project',
 };
 
+const isDevelopment = env.NODE_ENV === 'development';
+if (isDevelopment) {
+  metadata.title = `[DEV] ${metadata.title}`;
+}
+
 export default function RootLayout({
   children,
 }: Readonly<{

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,7 @@
-import Providers from '@/app/providers';
-import { cn } from '@/lib/utils';
 import type { Metadata } from 'next';
-import { Inter as FontSans } from 'next/font/google';
 import type { ReactNode } from 'react';
 import './globals.css';
-
-const fontSans = FontSans({ subsets: ['latin'], variable: '--font-sans' });
+import env from '@/env';
 
 export const metadata: Metadata = {
   title: 'NextJS Template',
@@ -22,15 +18,5 @@ export default function RootLayout({
 }: Readonly<{
   children: ReactNode;
 }>) {
-  return (
-    <html lang="en" suppressHydrationWarning>
-      <body
-        className={cn(
-          'min-h-screen bg-background font-sans antialiased',
-          fontSans.variable,
-        )}>
-        <Providers>{children}</Providers>
-      </body>
-    </html>
-  );
+  return children;
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,12 +1,18 @@
 'use client';
 
+import { I18nProvider } from '@/i18n/client';
+import type { Locale } from '@/i18n/i18n';
 import { AuthProvider } from '@/lib/providers/auth-provider';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from 'next-themes';
 import { type PropsWithChildren, useState } from 'react';
 import { toast } from 'sonner';
 
-export default function Providers({ children }: PropsWithChildren) {
+interface ProvidersProps extends PropsWithChildren {
+  locale: Locale;
+}
+
+export default function Providers({ children, locale }: ProvidersProps) {
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -48,7 +54,7 @@ export default function Providers({ children }: PropsWithChildren) {
         enableSystem
         disableTransitionOnChange>
         <QueryClientProvider client={queryClient}>
-          {children}
+          <I18nProvider locale={locale}>{children}</I18nProvider>
         </QueryClientProvider>
       </ThemeProvider>
     </AuthProvider>


### PR DESCRIPTION
1. Moved the root `<html>` tag and providers inside the `[locale]` fragment so that we can correctly set the `lang` attribute.
2. Added quality of life `[DEV]` prefix to page title - makes it easier to distinguish local development tabs from production or staging ones in the browser.
3. Moved `I18nProvider` inside `providers.tsx` file.